### PR TITLE
harbour.cson: recognize .hb extension

### DIFF
--- a/grammars/harbour.cson
+++ b/grammars/harbour.cson
@@ -3,6 +3,7 @@
 'fileTypes': [
   'prg'
   'ch'
+  'hb'
 ]
 'repository': {
   'block_doc_comment': {


### PR DESCRIPTION
.hb extension is used for Harbour Scripts.